### PR TITLE
💄 Update color for some UI elements to be more distinguish

### DIFF
--- a/lib/features/bottom_menus/views/bottom_menu_bar.dart
+++ b/lib/features/bottom_menus/views/bottom_menu_bar.dart
@@ -21,89 +21,95 @@ class BottomMenuBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BottomAppBar(
-      child: Row(
-        children: [
-          Consumer<UpdaterProvider>(builder: (_, setting, __) {
-            return IconButton(
-              tooltip: AppLocalizations.of(context)?.menuTooltip,
-              icon: setting.needForUpdate
-                  ? Badge(
-                      offset: Offset(5, -5),
-                      label: FaIcon(
-                        FontAwesomeIcons.download,
-                        size: 8,
-                        color: Theme.of(context).colorScheme.onError,
+    return Theme(
+      data: ThemeData(
+          // Set theme icon for the whole icon widget for this component
+          iconTheme: IconThemeData(
+              color: Theme.of(context).colorScheme.onPrimaryContainer)),
+      child: BottomAppBar(
+        color: Theme.of(context).colorScheme.primaryContainer.withAlpha(100),
+        child: Row(
+          children: [
+            Consumer<UpdaterProvider>(builder: (_, setting, __) {
+              return IconButton(
+                tooltip: AppLocalizations.of(context)?.menuTooltip,
+                icon: setting.needForUpdate
+                    ? Badge(
+                        offset: Offset(5, -5),
+                        label: FaIcon(
+                          FontAwesomeIcons.download,
+                          size: 8,
+                          color: Theme.of(context).colorScheme.onError,
+                        ),
+                        child: FaIcon(FontAwesomeIcons.bars),
+                      )
+                    : FaIcon(FontAwesomeIcons.bars),
+                onPressed: () => _showMenuModalBottomSheet(context),
+              ).withHotspot(
+                order: 3,
+                title: AppLocalizations.of(context)!
+                    .onboardingCoachmarkSettingTitle,
+                text: AppLocalizations.of(context)!
+                    .onboardingCoachmarkSettingContent,
+                flow: kOnboardingCoachmarkFlow,
+              );
+            }),
+            // These buttons were grouped into Row because we want to combine
+            // the coachmark
+            Row(
+              children: [
+                IconButton(
+                  icon: FaIcon(FontAwesomeIcons.calendarDays),
+                  tooltip: AppLocalizations.of(context)!.menuTimetableTooltip,
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        settings:
+                            const RouteSettings(name: 'Full Prayer Timetable'),
+                        builder: (_) => const MonthlyTimetablePage(),
                       ),
-                      child: const FaIcon(FontAwesomeIcons.bars),
-                    )
-                  : const FaIcon(FontAwesomeIcons.bars),
-              onPressed: () => _showMenuModalBottomSheet(context),
+                    );
+                  },
+                ),
+                IconButton(
+                  icon: FaIcon(FontAwesomeIcons.kaaba),
+                  tooltip: AppLocalizations.of(context)?.qiblaTitle,
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        settings: const RouteSettings(name: 'Qibla'),
+                        builder: (_) => GetStorage().read(kHasShowQiblaWarning)
+                            ? const QiblaPage()
+                            : const QiblaDisclaimerPage(),
+                      ),
+                    );
+                  },
+                ),
+                IconButton(
+                  icon: Icon(MyMptIcons.tasbih_plain),
+                  tooltip: "Tasbih",
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        settings: const RouteSettings(name: 'Tasbih'),
+                        builder: (_) => const TasbihPage(),
+                      ),
+                    );
+                  },
+                )
+              ],
             ).withHotspot(
-              order: 3,
-              title:
-                  AppLocalizations.of(context)!.onboardingCoachmarkSettingTitle,
+              order: 2,
+              title: AppLocalizations.of(context)!
+                  .onboardingCoachmarkUtilitiesTitle,
               text: AppLocalizations.of(context)!
-                  .onboardingCoachmarkSettingContent,
+                  .onboardingCoachmarkUtilitiesContent,
               flow: kOnboardingCoachmarkFlow,
-            );
-          }),
-          // These buttons were grouped into Row because we want to combine
-          // the coachmark
-          Row(
-            children: [
-              IconButton(
-                icon: const FaIcon(FontAwesomeIcons.calendarDays),
-                tooltip: AppLocalizations.of(context)!.menuTimetableTooltip,
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(
-                      settings:
-                          const RouteSettings(name: 'Full Prayer Timetable'),
-                      builder: (_) => const MonthlyTimetablePage(),
-                    ),
-                  );
-                },
-              ),
-              IconButton(
-                icon: const FaIcon(FontAwesomeIcons.kaaba),
-                // color: iconColour,
-                tooltip: AppLocalizations.of(context)?.qiblaTitle,
-                onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      settings: const RouteSettings(name: 'Qibla'),
-                      builder: (_) => GetStorage().read(kHasShowQiblaWarning)
-                          ? const QiblaPage()
-                          : const QiblaDisclaimerPage(),
-                    ),
-                  );
-                },
-              ),
-              IconButton(
-                icon: const Icon(MyMptIcons.tasbih_plain),
-                tooltip: "Tasbih",
-                onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      settings: const RouteSettings(name: 'Tasbih'),
-                      builder: (_) => const TasbihPage(),
-                    ),
-                  );
-                },
-              )
-            ],
-          ).withHotspot(
-            order: 2,
-            title:
-                AppLocalizations.of(context)!.onboardingCoachmarkUtilitiesTitle,
-            text: AppLocalizations.of(context)!
-                .onboardingCoachmarkUtilitiesContent,
-            flow: kOnboardingCoachmarkFlow,
-          ),
-        ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/prayer_time/views/prayer_time_list_widget.dart
+++ b/lib/features/prayer_time/views/prayer_time_list_widget.dart
@@ -256,10 +256,7 @@ class PrayerTimeCard extends StatelessWidget {
     return Consumer<SettingProvider>(
       builder: (_, settings, __) => Container(
         constraints: const BoxConstraints(maxWidth: 320),
-        margin: EdgeInsets.symmetric(
-          vertical: MediaQuery.of(context).size.height / 320,
-        ),
-        height: isOptional ? 55 : 80,
+        height: isOptional ? 55 : 78,
         child: Card(
           clipBehavior: Clip.hardEdge,
           child: InkWell(

--- a/lib/features/sharing/views/share_floating_action_button.dart
+++ b/lib/features/sharing/views/share_floating_action_button.dart
@@ -27,7 +27,8 @@ class ShareFloatingActionButton extends StatelessWidget {
       final localizations = AppLocalizations.of(context)!;
 
       return FloatingActionButton(
-        mini: true,
+        backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
+        foregroundColor: Theme.of(context).colorScheme.onTertiaryContainer,
         tooltip: localizations.shareTooltip,
         onPressed: () => showShareDialog(context),
         child: FaIcon(FontAwesomeIcons.shareNodes),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -68,14 +68,16 @@ class MyApp extends StatelessWidget {
               theme: ThemeData(
                 colorScheme: lightDynamic ??
                     ColorScheme.fromSeed(seedColor: _primaryColour),
+                cardTheme:
+                    CardThemeData(surfaceTintColor: lightDynamic?.surfaceTint),
                 useMaterial3: true,
               ),
               darkTheme: ThemeData.dark().copyWith(
                 colorScheme: darkDynamic ??
                     ColorScheme.fromSeed(
-                      seedColor: _primaryColour,
-                      brightness: Brightness.dark,
-                    ),
+                        seedColor: _primaryColour, brightness: Brightness.dark),
+                cardTheme:
+                    CardThemeData(surfaceTintColor: darkDynamic?.surfaceTint),
               ),
               themeMode: themeValue.themeMode,
               localizationsDelegates: AppLocalizations.localizationsDelegates,


### PR DESCRIPTION
This PR update the color theme to be more colorful to distinguish between UI elements.

Also, did some minor changes on the prayer time card list widget to be more compact so more data can fit into view. The sharing FAB button now no longer mini.

<img width="3265" height="3670" alt="image" src="https://github.com/user-attachments/assets/77099749-1f7d-46b5-823e-afbe8cd120f7" />

Previously, the colors would looks like this. Notice the color of bottom navigation bar is same as the scaffold background. There seems like no visual separation at all.

<img width="3547" height="1914" alt="image" src="https://github.com/user-attachments/assets/84878585-e819-4caf-b7bf-1d4d6d210df4" />